### PR TITLE
Numeric instability due to comparison with zero

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          python -m pip install -e .[doc]
+          pip install -r docs/requirements.txt
+          python -m pip install -e .
 
       - name: Compile Docs
         run: |

--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -8,3 +8,14 @@
     month         = {7},
     year          = {2023}
 }
+
+@software{spey_zenodo,
+    author    = {Jack Y. Araz},
+    title     = {SpeysideHEP/spey: v0.1.3},
+    month     = nov,
+    year      = 2023,
+    publisher = {Zenodo},
+    version   = {v0.1.3},
+    doi       = {10.5281/zenodo.10156354},
+    url       = {https://doi.org/10.5281/zenodo.10156354}
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![github](https://img.shields.io/static/v1?style=plastic&label&message=GitHub&logo=github&logoColor=black&color=white)](https://github.com/SpeysideHEP/spey)
 [![pypi](https://img.shields.io/static/v1?style=plastic&label&message=pypi&logo=python&logoColor=yellow&color=blue)](https://pypi.org/project/spey/)
-[![Documentation Status](https://readthedocs.org/projects/spey/badge/?style=plastic&version=latest)](https://spey.readthedocs.io/)
+[![Documentation Status](https://readthedocs.org/projects/spey/badge/?style=plastic&version=main)](https://spey.readthedocs.io/)
 
 ## Outline
 

--- a/docs/releases/changelog-v0.1.md
+++ b/docs/releases/changelog-v0.1.md
@@ -21,6 +21,10 @@
 * Backend inspection has been converted to inheritance property via ``ConverterBase``.
   ([#17](https://github.com/SpeysideHEP/spey/pull/17))
 
+* During POI upper limit computation, `sigma_mu` will be computed from Hessian, if available
+  before approximating through $q_{\mu,A}$.
+  [#25](https://github.com/SpeysideHEP/spey/pull/25)
+
 ## Bug Fixes
 
 * In accordance to the latest updates ```UnCorrStatisticsCombiner``` has been updated with

--- a/docs/releases/changelog-v0.1.md
+++ b/docs/releases/changelog-v0.1.md
@@ -1,4 +1,4 @@
-# Release notes v0.1.3
+# Release notes v0.1.4
 
 ## New features since last release
 
@@ -30,6 +30,10 @@
 * Execution error fix during likelihood computation for models with single nuisance parameter.
   ([#22](https://github.com/SpeysideHEP/spey/pull/22))
 
+* Numeric problem rising from `==` which has been updated to `np.isclose`
+  see issue [#23](https://github.com/SpeysideHEP/spey/issues/23).
+  [#25](https://github.com/SpeysideHEP/spey/pull/25)
+  
 ## Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     download_url=f"https://github.com/SpeysideHEP/spey/archive/refs/tags/v{version}.tar.gz",
     author="Jack Y. Araz",
-    author_email=("jack.araz@durham.ac.uk"),
+    author_email=("jackaraz@jlab.org"),
     license="MIT",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/spey/_version.py
+++ b/src/spey/_version.py
@@ -1,3 +1,3 @@
 """Version number (major.minor.patch[-label])"""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/src/spey/base/hypotest_base.py
+++ b/src/spey/base/hypotest_base.py
@@ -892,7 +892,11 @@ class HypothesisTestingBase(ABC):
 
         if None in [low_init, hig_init]:
             muhat = maximum_likelihood[0] if maximum_likelihood[0] > 0.0 else 0.0
-            sigma_mu = self.sigma_mu(muhat, expected=expected) if muhat != 0.0 else 1.0
+            sigma_mu = (
+                self.sigma_mu(muhat, expected=expected)
+                if not np.isclose(muhat, 0.0)
+                else 1.0
+            )
             low_init = low_init or muhat + 1.5 * sigma_mu
             hig_init = hig_init or muhat + 2.5 * sigma_mu
 

--- a/src/spey/optimizer/scipy_tools.py
+++ b/src/spey/optimizer/scipy_tools.py
@@ -1,9 +1,10 @@
 """Optimisation tools based on scipy"""
 
-from typing import Callable, List, Tuple, Dict
+import warnings
+from typing import Callable, Dict, List, Tuple
 
-import warnings, scipy
 import numpy as np
+import scipy
 
 
 def minimize(


### PR DESCRIPTION
This PR resolves an issue arising due to numeric instability during POI UL computation. Direct comparison with zero is not accurate; hence has been replaced by `np.isclose`.