### PR TITLE
Add Normal/MultivariateNormal PDFs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,5 @@ jobs:
         python -m pip install -e .
     - name: Test with pytest
       run: |
+        python -c 'import spey;spey.about()'
         pytest --cov=spey tests/*py #--cov-fail-under 99

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
     "description": "smooth inference for reinterpretation studies",
     "license": "MIT",
-    "title": "SpeysideHEP/spey: v0.1.8",
-    "version": "v0.1.8",
+    "title": "SpeysideHEP/spey: v0.1.9",
+    "version": "v0.1.9",
     "upload_type": "software",
     "creators": [
         {
@@ -18,7 +18,9 @@
         "statistics",
         "fitting",
         "scipy",
-        "auto-differentiation"
+        "auto-differentiation",
+        "inference",
+        "differentiable programming"
     ],
     "related_identifiers": [
         {
@@ -29,7 +31,7 @@
         },
         {
             "scheme": "url",
-            "identifier": "https://github.com/SpeysideHEP/spey/tree/v0.1.8",
+            "identifier": "https://github.com/SpeysideHEP/spey/tree/v0.1.9",
             "relation": "isSupplementTo"
         },
         {

--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -15,11 +15,11 @@
 
 @software{spey_zenodo,
     author    = {Araz, Jack Y.},
-    title     = {SpeysideHEP/spey: v0.1.8},
+    title     = {SpeysideHEP/spey: v0.1.9},
     month     = feb,
     year      = 2024,
     publisher = {Zenodo},
-    version   = {v0.1.8},
+    version   = {v0.1.9},
     doi       = {10.5281/zenodo.10671596},
     url       = {https://doi.org/10.5281/zenodo.10671596}
 }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -137,6 +137,8 @@ Simple PDFs
     :toctree: _generated/
 
     simple_pdf.Poisson
+    simple_pdf.Gaussian
+    simple_pdf.MultivariateNormal
 
 
 Exceptions

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,5 +1,8 @@
 Known Issues
 ============
 
-* It has been observed that the Scipy version and its compiler, which is used for maximising and profiling
-  the likelihood can have a slight effect on the results.
+* It has been observed that the Scipy version and its compiler, which is used for maximising and profiling the likelihood can have a slight effect on the results.
+
+* NumPy v2.0.0 does not work with autograd, which is used in "default_pdf.XXX" likelihoods. The dependencies are reformulated accordingly.
+
+* There are some dependency issues in some sub-versions of Python 3.12. This is due to deprecated system packages. Updates can be followed in PR `#39 <https://github.com/SpeysideHEP/spey/pull/39>`_.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -19,9 +19,9 @@ Plug-ins
    * - ``'default_pdf.poisson'``
      - :ref:`Poisson distribution, without uncertainties.  <poisson>`
    * - ``'default_pdf.normal'``
-     - :ref:`Gaussian distribution.  <third_moment_expansion>`
+     - :ref:`Gaussian distribution.  <normal>`
    * - ``'default_pdf.multivariate_normal'``
-     - :ref:`Multivariate Normal distribution.  <third_moment_expansion>`
+     - :ref:`Multivariate Normal distribution.  <multinormal>`
    * - ``'pyhf'``
      - `External plug-in <https://spey-pyhf.readthedocs.io>`_ uses ``pyhf`` to construct the likelihoods.
    * - ``'pyhf.uncorrelated_background'``
@@ -354,6 +354,78 @@ It can take any number of yields.
  * ``data``: keyword for observations. It can take one or more values as a list or NumPy array.
  * ``analysis`` (optional): Unique identifier for the analysis.
  * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
+
+.. _normal:
+
+``'default_pdf.normal'``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Simple Normal distribution implementation;
+
+.. math::
+
+    \mathcal{L}(\mu) = \prod_{i\in{\rm bins}} \frac{1}{\sigma^i \sqrt{2\pi}} \exp\left[-\frac{1}{2} \left(\frac{\mu n_s^i + n_b^i - n^i}{\sigma^i} \right)^2 \right]
+
+It can take any number of yields.
+
+.. code-block:: python3
+    :linenos:
+
+    >>> pdf_wrapper = spey.get_backend("default_pdf.normal")
+    >>> statistical_model = pdf_wrapper(
+    ...     signal_yields=[12.0, 15.0],
+    ...     background_yields=[50.0,48.0],
+    ...     data=[36, 33],
+    ...     absolute_uncertainties=[20.0, 10.0],
+    ...     analysis="example",
+    ...     xsection=0.123,
+    ... )
+
+**Arguments:**
+
+ * ``signal_yields``: keyword for signal yields. It can take one or more values as a list or NumPy array.
+ * ``background_yields``: keyword for background-only expectations. It can take one or more values as a list or NumPy array.
+ * ``data``: keyword for observations. It can take one or more values as a list or NumPy array.
+ * ``absolute_uncertainties``: absolute uncertainties on the background
+ * ``analysis`` (optional): Unique identifier for the analysis.
+ * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
+
+
+.. _multinormal:
+
+``'default_pdf.multivariate_normal'``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Simple Normal distribution implementation;
+
+.. math::
+
+    \mathcal{L}(\mu) = \frac{1}{\sqrt{(2\pi)^k {\rm det}[\Sigma] }} \exp\left[-\frac{1}{2} (\mu n_s + n_b - n)\Sigma^{-1} (\mu n_s + n_b - n)^T \right]
+
+It can take any number of yields.
+
+.. code-block:: python3
+    :linenos:
+
+    >>> pdf_wrapper = spey.get_backend("default_pdf.multivariate_normal")
+    >>> statistical_model = pdf_wrapper(
+    ...     signal_yields=[12.0, 15.0],
+    ...     background_yields=[50.0,48.0],
+    ...     data=[36, 33],
+    ...     covariance_matrix=[[144.0,13.0], [25.0, 256.0]],
+    ...     analysis="example",
+    ...     xsection=0.123,
+    ... )
+
+**Arguments:**
+
+ * ``signal_yields``: keyword for signal yields. It can take one or more values as a list or NumPy array.
+ * ``background_yields``: keyword for background-only expectations. It can take one or more values as a list or NumPy array.
+ * ``data``: keyword for observations. It can take one or more values as a list or NumPy array.
+ * ``covariance_matrix``: covariance matrix (square matrix)
+ * ``analysis`` (optional): Unique identifier for the analysis.
+ * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
+
 
 
 External Plug-ins

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -3,6 +3,32 @@
 Plug-ins
 ========
 
+.. list-table::
+   :header-rows: 1
+
+   * - Keyword
+     - Summary
+   * - ``'default_pdf.uncorrelated_background'``
+     - :ref:`Combination of Poisson and Gaussian PDF, assuming uncorrelated bins. <uncorrelated_background>`
+   * - ``'default_pdf.correlated_background'``
+     - :ref:`Combination of Poisson and Gaussian PDF, with correlated bins. <correlated_background>`
+   * - ``'default_pdf.third_moment_expansion'``
+     - :ref:`Simplified likelihood, extended with third moments of the background. <third_moment_expansion>`
+   * - ``'default_pdf.effective_sigma'``
+     - :ref:`Simplified likelihood, extended with asymmetric uncertainties.  <effective_sigma>`
+   * - ``'default_pdf.poisson'``
+     - :ref:`Poisson distribution, without uncertainties.  <poisson>`
+   * - ``'default_pdf.normal'``
+     - :ref:`Gaussian distribution.  <third_moment_expansion>`
+   * - ``'default_pdf.multivariate_normal'``
+     - :ref:`Multivariate Normal distribution.  <third_moment_expansion>`
+   * - ``'pyhf'``
+     - `External plug-in <https://spey-pyhf.readthedocs.io>`_ uses ``pyhf`` to construct the likelihoods.
+   * - ``'pyhf.uncorrelated_background'``
+     - `External plug-in <https://spey-pyhf.readthedocs.io>`_ constructs ``pyhf``-based uncorrelated likelihoods.
+   * - ``'pyhf.simplify'``
+     - `See doc. <https://spey-pyhf.readthedocs.io/en/main/simplify.html>`_ converts full ``pyhf`` likelihoods into simplified framework.
+
 .. meta::
     :property=og:title: Plug-ins
     :property=og:description: Currently supported likelihood prescriptions.
@@ -61,6 +87,8 @@ All default plug-ins are defined using the following main likelihood structure
 
 The first term represents the primary model, and the second represents the constraint model.
 
+.. _uncorrelated_background:
+
 ``'default_pdf.uncorrelated_background'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -110,6 +138,8 @@ This particular example implements a two-bin histogram with uncorrelated bins. T
 For all the properties of :obj:`~spey.StatisticalModel` class, we refer the reader to the corresponding
 API description.
 
+.. _correlated_background:
+
 ``'default_pdf.correlated_background'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -158,6 +188,8 @@ as expected.
    and both dimensions should match the number of ``background_yields`` given as input.
  * ``analysis`` (optional): Unique identifier for the analysis.
  * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
+
+.. _third_moment_expansion:
 
 ``'default_pdf.third_moment_expansion'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -230,6 +262,7 @@ reduced the exclusion limit.
  * ``analysis`` (optional): Unique identifier for the analysis.
  * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
 
+.. _effective_sigma:
 
 ``'default_pdf.effective_sigma'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -288,6 +321,8 @@ Once again, the exclusion limit can be computed as
    for background given as :math:`{n_b}_{-\sigma^-}^{+\sigma^+}` the input should be [(:math:`|\sigma^+|`, :math:`|\sigma^-|`)].
  * ``analysis`` (optional): Unique identifier for the analysis.
  * ``xsection`` (optional): Cross-section value for the signal hypothesis. Units determined by the user.
+
+.. _poisson:
 
 ``'default_pdf.poisson'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/changelog-v0.1.md
+++ b/docs/releases/changelog-v0.1.md
@@ -14,6 +14,9 @@ Specific upgrades for the latest release can be found [here](https://github.com/
   (Request by Veronica Sanz for EFT studies).
   ([#22](https://github.com/SpeysideHEP/spey/pull/22))
 
+* Normal and multivariate normal distributions have been added (for integration to Contur, requested by Jon Butterworth and Joe Egan).
+  ([#40](https://github.com/SpeysideHEP/spey/pull/40))
+
 ## Improvements
 
 * Backend inspection has been added for the models that act like intermediate functions.
@@ -66,8 +69,12 @@ Specific upgrades for the latest release can be found [here](https://github.com/
 * Bug fix in signal uncertainty synthesizer
   ([#34](https://github.com/SpeysideHEP/spey/pull/34))
 
-* Signal uncertainties were causing a narrower $\chi^2$ distribution due to the weight of the constraint term. 
+* Signal uncertainties were causing a narrower $\chi^2$ distribution due to the weight of the constraint term.
   ([#38](https://github.com/SpeysideHEP/spey/pull/38))
+
+* Scipy and Autograd version limitations have been relieved. But there is a clash with numpy v2.0
+  so numpy version has been limited to less than 2.0.
+  ([#40](https://github.com/SpeysideHEP/spey/pull/40))
 
 ## Contributors
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("src/spey/_version.py", mode="r", encoding="UTF-8") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "numpy>=1.21.6",
+    "numpy>=1.21.6, <2.0.0",
     "scipy>=1.10.0",
     "autograd>=1.5",
     "semantic_version~=2.10",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ backend_plugins = [
     "default_pdf.third_moment_expansion = spey.backends.default_pdf:ThirdMomentExpansion",
     "default_pdf.effective_sigma = spey.backends.default_pdf:EffectiveSigma",
     "default_pdf.poisson = spey.backends.default_pdf.simple_pdf:Poisson",
+    "default_pdf.normal = spey.backends.default_pdf.simple_pdf:Gaussian",
+    "default_pdf.multivariate_normal = spey.backends.default_pdf.simple_pdf:MultivariateNormal",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ with open("src/spey/_version.py", mode="r", encoding="UTF-8") as f:
 
 requirements = [
     "numpy>=1.21.6",
-    "scipy==1.10.0",
-    "autograd==1.5",
+    "scipy>=1.10.0",
+    "autograd>=1.5",
     "semantic_version~=2.10",
     "tqdm>=4.64.0",
     "requests>=2.31.0",

--- a/src/spey/__init__.py
+++ b/src/spey/__init__.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import textwrap
-from typing import Any, Callable, Dict, List, Optional, Text, Tuple, Union, Literal
+from typing import Any, Callable, Dict, List, Literal, Optional, Text, Tuple, Union
 
 import numpy as np
 import pkg_resources
@@ -14,7 +14,7 @@ from spey.combiner import UnCorrStatisticsCombiner
 from spey.interface.statistical_model import StatisticalModel, statistical_model_wrapper
 from spey.system import logger
 from spey.system.exceptions import PluginError
-from spey.system.webutils import get_bibtex, check_updates, ConnectionError
+from spey.system.webutils import ConnectionError, check_updates, get_bibtex
 
 from ._version import __version__
 from .about import about

--- a/src/spey/_version.py
+++ b/src/spey/_version.py
@@ -1,3 +1,3 @@
 """Version number (major.minor.patch[-label])"""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/src/spey/backends/default_pdf/simple_pdf.py
+++ b/src/spey/backends/default_pdf/simple_pdf.py
@@ -325,7 +325,8 @@ class Gaussian(SimplePDFBase):
 
     .. math::
 
-        \mathcal{L}(\mu) = \prod_{i\in{\rm bins}}{\rm Gauss}(n^i|\mu n_s^i + n_b^i, \sigma_b^i)
+        \mathcal{L}(\mu) = \prod_{i\in{\rm bins}} \frac{1}{\sigma^i \sqrt{2\pi}}
+        \exp\left[-\frac{1}{2} \left(\frac{\mu n_s^i + n_b^i - n^i}{\sigma^i} \right)^2 \right]
 
     where :math:`n_{s,b}` are signal and background yields and :math:`n` are the observations.
 
@@ -368,7 +369,8 @@ class MultivariateNormal(SimplePDFBase):
 
     .. math::
 
-        \mathcal{L}(\mu) = \mathcal{N}(\mathbf{n}|\mu \mathbf{n}_s + \mathbf{n}_b, \Sigma_b)
+        \mathcal{L}(\mu) = \frac{1}{\sqrt{(2\pi)^k {\rm det}[\Sigma] }}
+        \exp\left[-\frac{1}{2} (\mu n_s + n_b - n)\Sigma^{-1} (\mu n_s + n_b - n)^T \right]
 
     where :math:`n_{s,b}` are signal and background yields and :math:`n` are the observations.
 
@@ -378,7 +380,8 @@ class MultivariateNormal(SimplePDFBase):
         data (``List[int]``): data
         covariance_matrix (``List[List[float]]``): covariance matrix (square matrix)
 
-          * If you have correlation matrix and absolute uncertainties please use :func:`~spey.helper_functions.correlation_to_covariance`
+          * If you have correlation matrix and absolute uncertainties please use
+            :func:`~spey.helper_functions.correlation_to_covariance`
 
     """
 

--- a/src/spey/backends/default_pdf/simple_pdf.py
+++ b/src/spey/backends/default_pdf/simple_pdf.py
@@ -330,6 +330,8 @@ class Gaussian(SimplePDFBase):
 
     where :math:`n_{s,b}` are signal and background yields and :math:`n` are the observations.
 
+    .. versionadded:: 0.1.9
+
     Args:
         signal_yields (``List[float]``): signal yields
         background_yields (``List[float]``): background yields
@@ -373,6 +375,8 @@ class MultivariateNormal(SimplePDFBase):
         \exp\left[-\frac{1}{2} (\mu n_s + n_b - n)\Sigma^{-1} (\mu n_s + n_b - n)^T \right]
 
     where :math:`n_{s,b}` are signal and background yields and :math:`n` are the observations.
+
+    .. versionadded:: 0.1.9
 
     Args:
         signal_yields (``List[float]``): signal yields

--- a/src/spey/backends/distributions.py
+++ b/src/spey/backends/distributions.py
@@ -11,7 +11,7 @@ from scipy.stats import multivariate_normal, norm, poisson
 
 from spey.system.exceptions import DistributionError
 
-# pylint: disable=E1101, W1203
+# pylint: disable=E1101, W1203, E1121
 
 log = logging.getLogger("Spey")
 

--- a/src/spey/backends/distributions.py
+++ b/src/spey/backends/distributions.py
@@ -2,12 +2,14 @@
 
 import logging
 import warnings
-from typing import Any, Callable, Dict, List, Text, Union
+from typing import Any, Callable, Dict, List, Literal, Text, Union
 
 import autograd.numpy as np
 from autograd.scipy.special import gammaln
 from autograd.scipy.stats.poisson import logpmf
 from scipy.stats import multivariate_normal, norm, poisson
+
+from spey.system.exceptions import DistributionError
 
 # pylint: disable=E1101, W1203
 
@@ -187,12 +189,26 @@ class MainModel:
           lambda values of poisson distribution. It takes nuisance parameters as input.
     """
 
-    def __init__(self, loc: Callable[[np.ndarray], np.ndarray]):
-        self._pdf = lambda pars: Poisson(loc(pars))
+    def __init__(
+        self,
+        loc: Callable[[np.ndarray], np.ndarray],
+        cov: np.ndarray = None,
+        pdf_type: Literal["poiss", "gauss", "multivariategauss"] = "poiss",
+    ):
+        self.pdf_type = pdf_type
+        """Type of the PDF"""
+        if pdf_type == "poiss":
+            self._pdf = lambda pars: Poisson(loc(pars))
+        elif pdf_type == "gauss" and cov is not None:
+            self._pdf = lambda pars: Normal(loc=loc(pars), scale=cov)
+        elif pdf_type == "multivariategauss" and cov is not None:
+            self._pdf = lambda pars: MultivariateNormal(mean=loc(pars), cov=cov)
+        else:
+            raise DistributionError("Unknown pdf type or associated input.")
 
     def expected_data(self, pars: np.ndarray) -> np.ndarray:
         """The expectation value of the main model."""
-        return self._pdf(pars).loc
+        return self._pdf(pars).expected_data()
 
     def sample(self, pars: np.ndarray, sample_size: int) -> np.ndarray:
         r"""
@@ -207,7 +223,10 @@ class MainModel:
             ``np.ndarray``:
             sampled data
         """
-        return self._pdf(pars).sample(sample_size)
+        if self.pdf_type == "poiss":
+            return self._pdf(pars).sample(sample_size)
+
+        return self._pdf(pars).sample(pars, sample_size)
 
     def log_prob(self, pars: np.ndarray, data: np.ndarray) -> np.ndarray:
         r"""

--- a/src/spey/system/exceptions.py
+++ b/src/spey/system/exceptions.py
@@ -76,3 +76,7 @@ class CalculatorNotAvailable(Exception):
 
 class CombinerNotAvailable(Exception):
     """Unavailable combination routine exception"""
+
+
+class DistributionError(Exception):
+    """Unknown Distribution"""

--- a/tests/test_default_pdf.py
+++ b/tests/test_default_pdf.py
@@ -123,3 +123,48 @@ def test_poisson():
         stat_model.exclusion_confidence_level()[0], 0.9999807105228611
     ), "CLs is wrong"
     assert np.isclose(stat_model.sigma_mu(1.0), 0.5573350296644078), "Sigma mu is wrong"
+
+
+def test_normal():
+    """tester for gaussian model"""
+
+    statistical_model = spey.get_backend("default_pdf.normal")(
+        signal_yields=[12.0],
+        background_yields=[50.0],
+        data=[36],
+        absolute_uncertainties=[20.0],
+    )
+
+    assert np.isclose(
+        statistical_model.chi2(),
+        2.0
+        * (
+            0.5 * ((12.0 + 50.0 - 36.0) ** 2 / 20.0**2)
+            - (0.5 * ((50.0 - 36.0) ** 2 / 20.0**2))
+        ),
+    ), "Gaussian chi2 is wrong"
+
+
+def test_multivariate_gauss():
+    """tester for multivar gauss"""
+
+    signal = np.array([12.0, 15.0])
+    bkg = np.array([50.0, 48.0])
+    data = np.array([36, 33])
+    cov = np.array([[144.0, 13.0], [25.0, 256.0]])
+
+    statistical_model = spey.get_backend("default_pdf.multivariate_normal")(
+        signal_yields=signal,
+        background_yields=bkg,
+        data=data,
+        covariance_matrix=cov,
+    )
+
+    assert np.isclose(
+        statistical_model.chi2(),
+        2.0
+        * (
+            (0.5 * (signal + bkg - data) @ np.linalg.inv(cov) @ (signal + bkg - data))
+            - (0.5 * (bkg - data) @ np.linalg.inv(cov) @ (bkg - data))
+        ),
+    )


### PR DESCRIPTION
This PR extends the PDF list with normal and multivariate normal distributions:

```python
spey.AvailableBackends()
# ['pyhf',
#  'pyhf.simplify',
#  'pyhf.uncorrelated_background',
#  'default_pdf.correlated_background',
#  'default_pdf.effective_sigma',
#  'default_pdf.multivariate_normal',
#  'default_pdf.normal',
#  'default_pdf.poisson',
#  'default_pdf.third_moment_expansion',
#  'default_pdf.uncorrelated_background']


pdf_wrapper = spey.get_backend("default_pdf.multivariate_normal")
statistical_model1 = pdf_wrapper(
    signal_yields=[12.0, 15.0],
    background_yields=[50.0,48.0],
    data=[36, 33],
    covariance_matrix=[[144.0,13.0], [25.0, 256.0]],
)

pdf_wrapper = spey.get_backend("default_pdf.normal")
statistical_model2 = pdf_wrapper(
    signal_yields=[12.0, 15.0],
    background_yields=[50.0,48.0],
    data=[36, 33],
    absolute_uncertainties=[20.0,10.0],
)

print(statistical_model2.chi2())
# 7.949999999999935

print(statistical_model1.exclusion_confidence_level(), statistical_model2.exclusion_confidence_level())
# ([0.9591145211259625], [0.9890014596358632])
```
