### PR TITLE
Reduce errors to warnings, and handle left side fail better

### DIFF
--- a/src/spey/base/hypotest_base.py
+++ b/src/spey/base/hypotest_base.py
@@ -1088,11 +1088,11 @@ class HypothesisTestingBase(ABC):
                 )
                 results.append(x0)
             else:
-                log.error(
+                log.warn(
                     "Can not find the roots on the left side."
                     " Please check your chi^2 distribution, it might be too wide."
                 )
-                results.append(-1e5 if hig >= -1e5 else np.nan)
+                results.append(-1e5 if hig <= -1e5 else np.nan)
 
         if limit_type in ["right", "two-sided"]:
             is_muhat_le_0 = np.isclose(muhat, 0.0) or muhat < 0.0
@@ -1136,7 +1136,7 @@ class HypothesisTestingBase(ABC):
                 )
                 results.append(x0)
             else:
-                log.error(
+                log.warn(
                     "Can not find the roots on the right side."
                     " Please check your chi^2 distribution, it might be too wide."
                 )


### PR DESCRIPTION
Producing errors when the chi2 is broad makes this very verbose for some contur runs (which can have low signal) so I reduced this to a warning.

Also, I think the limit comparison for left-sided limits had the wrong sign.

Both fixed here.
